### PR TITLE
Fixes #3: Open new links in default OS browser

### DIFF
--- a/app/main/slack.ts
+++ b/app/main/slack.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, HandlerDetails, shell } from "electron";
 import path from "path";
 import { WindowManager, WindowName } from "../WindowManager";
 
@@ -15,5 +15,12 @@ export const createSlackWindow = async (): Promise<void> => {
         }
     });
 
-    if (window) await window.loadURL("https://trilobot.slack.com");
+    if (window) {
+        await window.loadURL("https://trilobot.slack.com");
+
+        window.webContents.setWindowOpenHandler(({ url }: HandlerDetails) => {
+            shell.openExternal(url);
+            return { action: "deny" };
+        });
+    }
 };


### PR DESCRIPTION
 When a hyperlink is clicked and a new window is opened, it will now open for the user's default OS browser, not an embedded BrowserWindow.